### PR TITLE
Changed Unsaved Prompt

### DIFF
--- a/src/saves.js
+++ b/src/saves.js
@@ -21,7 +21,7 @@ const action_new_notebook = () => {
 		return;
 	}
 
-	prompt_confirm('There are unsaved changes.\nAre you sure?')
+	prompt_confirm('There are unsaved changes.\nAre you sure you want to continue?\n All unsaved changes will be lost.')
 		.then(res => {
 			if (res == 'Yes') { new_notebook(); }
 		})


### PR DESCRIPTION
The unsaved prompt was updated to clearly identify possible data loss. 

Original: "There are unsaved changes. Are you sure"

Changed: "There are unsaved changes.\nAre you sure you want to continue?\nAll unsaved changes will be lost."

